### PR TITLE
Capitalize "P" in "Psalms" in WCF 21.5

### DIFF
--- a/data/westminster/wcf.yaml
+++ b/data/westminster/wcf.yaml
@@ -2781,7 +2781,7 @@ chapters:
         text: >
           The reading of the Scriptures with godly fear;[a] the sound preaching;[b]
           and conscionable hearing of the Word, in obedience unto God with understanding,
-          faith, and reverence;[c] singing of psalms with grace in the heart;[d] as,
+          faith, and reverence;[c] singing of Psalms with grace in the heart;[d] as,
           also, the due administration and worthy receiving of the sacraments instituted
           by Christ; are all parts of the ordinary religious worship of God:[e] besides
           religious oaths,[f] vows,[g] solemn fastings,[h] and thanksgivings upon


### PR DESCRIPTION
This is capitalized in the recently published critical edition[1]
and there are no variants noted.

Although capitalization did not carry the same meaning or have the same
consistency as today, it's reasonable to conclude that this paragraph is
referring to the canonical book of Psalms based on contemporary writings
and the practice of the Scottish church.

This lack of capitalization in modern reproductions has been appealed
to by proponents of uninspired songs in worship to deny the Westminster
Assembly spoke of the Psalter. This capitalization change is meaningful

[1]: John Bower, “Chap. XXI. Of Religious Worship, and the Sabbath Day,”
in _The Confession of Faith: a Critical Text and Introduction_
(Grand Rapids, MI, MI: Reformation Heritage Books, 2020), pp. 221-221.