### PR TITLE
OSIS citation typos - WSC, WCF & Savory (w/ comments on data inconsistencies in the 1689)

### DIFF
--- a/data/british/savoy.yaml
+++ b/data/british/savoy.yaml
@@ -3524,7 +3524,7 @@ chapters:
             - Rom.9.22
             - 2Thess.1.7-2Thess.1.8
           c:
-            - Matt.25.31-Matt.25.24
+            - Matt.25.31-Matt.25.46
             - Acts.3.19
             - 2Thess.1.7
           d:

--- a/data/westminster/wcf.yaml
+++ b/data/westminster/wcf.yaml
@@ -4001,7 +4001,7 @@ chapters:
             - Rom.9.22
             - 2Thess.1.7-2Thess.1.8
           c:
-            - Matt.25.31-Matt.25.24
+            - Matt.25.31-Matt.25.46
             - Acts.3.19
             - 2Thess.1.7
           d:

--- a/data/westminster/wsc.yaml
+++ b/data/westminster/wsc.yaml
@@ -320,7 +320,7 @@ questions:
       a:
         - Acts.15.14-Acts.15.16
       b:
-        - Isa.32.22
+        - Isa.33.22
       c:
         - Isa.32.1-Isa.32.2
       d:
@@ -1095,7 +1095,7 @@ questions:
       a:
         - Acts.11.18
       b:
-        - Acts.2.37-Acts.2.28
+        - Acts.2.37-Acts.2.38
       c:
         - Joel.2.12
         - Jer.3.22


### PR DESCRIPTION
WSC b973533 - there is no Isaiah 32:22.

Comments on Data Inconsistencies in the 1689 [here](https://github.com/reformed-standards/compendium/issues/14)