### PR TITLE
BCoF Typo and Validation of Verses Property on Question/Article Dict

### DIFF
--- a/data/three-forms-of-unity/belgic-confession.yaml
+++ b/data/three-forms-of-unity/belgic-confession.yaml
@@ -20,7 +20,7 @@ chapters:
       book, wherein all creatures, great and small, are as so many characters
       leading us to contemplate the invisible things of God, namely, his power
       and divinity, as the apostle Paul saith, Romans 1:20. All which things
-      are sufficient to convincemen, and leave them without excuse. Secondly,
+      are sufficient to convince men, and leave them without excuse. Secondly,
       he makes himself more clearly and fully known to us by his holy and
       divine Word, that is to say, as far as is necessary for us to know in
       this life, to his glory and our salvation.

--- a/data/three-forms-of-unity/heidelberg-catechism.yaml
+++ b/data/three-forms-of-unity/heidelberg-catechism.yaml
@@ -1798,7 +1798,7 @@ days:
       - question: >-
           Are both word and sacraments, then, ordained and appointed for this
           end, that they may direct our faith to the sacrifice of Jesus Christ
-          on the cross, as the only ground of our salvation? (a)
+          on the cross, as the only ground of our salvation? [a]
         number: 67
         answer: >-
           Yes, indeed: for the Holy Ghost teaches us in the gospel, and assures

--- a/test/validate_data_files.py
+++ b/test/validate_data_files.py
@@ -32,6 +32,9 @@ def read_yaml_file(filename):
     data = open(filename).read()
     return yaml.load(data, Loader=yaml.Loader)
 
+def _validate_verses(text_w_ref, obj):
+    for ref in obj['verses']:
+        assert '[' + str(ref) + ']' in text_w_ref, 'Missing Citation ' + str(ref) + ' from ' + str(obj['number'])
 
 def validate_confession(data):
     for chapter in data['chapters']:
@@ -53,6 +56,8 @@ def validate_confession(data):
 
         for article in chapter['articles']:
             assert isinstance(article, dict), 'Article not a dict'
+            if 'verses' in article:
+                _validate_verses(article['text'], article)
 
             assert 'number' in article, 'Missing article number'
             assert 'text' in article, 'Missing text in article'
@@ -69,7 +74,6 @@ def _validate_question(question):
     assert 'question' in question, 'Missing question'
     assert 'answer' in question, 'Missing answer'
     assert 'number' in question, 'Missing question number'
-    assert 'verses' in question, 'Missing verses'
 
     assert isinstance(question['question'], str), \
         'Question not a string'
@@ -77,12 +81,14 @@ def _validate_question(question):
         'Answer not a string'
     assert isinstance(question['number'], int), \
         'Question number not an int'
+    if 'verses' in question:
+        _validate_verses(question['answer'] + question['question'], question)
 
 
 def validate_catechism(data):
     if 'days' in data:
         for day in data['days']:
-            for question in day:
+            for question in day['questions']:
                 _validate_question(question)
     else:
         for question in data['questions']:
@@ -116,6 +122,9 @@ def validate_file(filename):
             validate_confession(data)
 
         if 'questions' in data:
+            validate_catechism(data)
+
+        if 'days' in data:
             validate_catechism(data)
 
     except Exception as err:


### PR DESCRIPTION
Two things:

**Typos**
- Fixes small typos in Belgic confession and Heidelberg Catechism

**Tests**
- adds new method in testing script to validate that any key in the verses dict is present as a string value `[key]` in either the question, answer, or text property.
