### PR TITLE
WLC, WSC + Heidelberg Catechism: Citation Typos and Corrections

### DIFF
--- a/data/three-forms-of-unity/heidelberg-catechism.yaml
+++ b/data/three-forms-of-unity/heidelberg-catechism.yaml
@@ -2606,9 +2606,6 @@ days:
             - Gal.4.8
             - Eph.2.12
             - 1John.2.23
-          but:
-            - 2John.1.9
-            - John.5.23
   - number: 35
     questions:
       - question: >-

--- a/data/three-forms-of-unity/heidelberg-catechism.yaml
+++ b/data/three-forms-of-unity/heidelberg-catechism.yaml
@@ -3241,9 +3241,7 @@ days:
             - John.16.23
             - Dan.9.17
             - Dan.9.18
-          h:
             - Matt.7.8
-            - Ps.27.8
       - question: >-
           What has God commanded us to ask of him?
         number: 118

--- a/data/three-forms-of-unity/heidelberg-catechism.yaml
+++ b/data/three-forms-of-unity/heidelberg-catechism.yaml
@@ -3253,7 +3253,7 @@ days:
           turning. Matt.6:33 But seek ye first the kingdom of God, and his
           righteousness; and all these things shall be added unto you.
       - question: >-
-          What are the words of that prayer? (a)
+          What are the words of that prayer?
         number: 119
         answer: >-
           Our Father which art in heaven, 1 Hallowed be thy name. 2 Thy kingdom
@@ -3261,7 +3261,7 @@ days:
           day our daily bread. 5 And forgive us our debts, as we forgive our
           debtors. 6 And lead us not into temptation, but deliver us from evil.
           For thine is the kingdom, and the power, and the glory, for ever.
-          Amen.
+          Amen.[a]
         verses:
           a:
             - Matt.6.9

--- a/data/westminster/wlc.yaml
+++ b/data/westminster/wlc.yaml
@@ -1617,7 +1617,7 @@ questions:
     answer: >-
       Faith justifies a sinner in the sight of God, not because of those
       other graces which do always accompany it, or of good works that are
-      the fruits of it,[3] nor as if the grace of faith, or any act thereof,
+      the fruits of it,[1] nor as if the grace of faith, or any act thereof,
       were imputed to him for his justification;[2] but only as it is an
       instrument by which he receiveth and applies Christ and his
       righteousness.[3]

--- a/data/westminster/wlc.yaml
+++ b/data/westminster/wlc.yaml
@@ -5411,8 +5411,8 @@ questions:
       for sin;[7] in earnest hungering and thirsting after Christ,[8]
       feeding on him by faith,[9] receiving of his fulness,[10] trusting in
       his merits,[11] rejoicing in his love,[12] giving thanks for his
-      grace;[13] in renewing of their covenant with God, and love to all the
-      saints.[14]
+      grace;[13] in renewing of their covenant with God,[14] and love to all the
+      saints.[15]
     verses:
       1:
         - Lev.10.3

--- a/data/westminster/wlc.yaml
+++ b/data/westminster/wlc.yaml
@@ -3416,8 +3416,8 @@ questions:
       corrections;[7] fidelity to,[8] defense [9] and maintenance of their
       persons and authority, according to their several ranks, and the
       nature of their places;[10] bearing with their infirmities, and
-      covering them in love, that so they may be an honor to them and to
-      their government.[11]
+      covering them in love,[11] that so they may be an honor to them and to
+      their government.[12]
     verses:
       1:
         - Mal.1.6

--- a/data/westminster/wlc.yaml
+++ b/data/westminster/wlc.yaml
@@ -662,13 +662,10 @@ questions:
         - Gal.5.22-Gal.5.23
       7:
         - Ezek.36.27
+        - 2Cor.5.14-2Cor.5.15
       8:
         - Jas.2.18
         - Jas.2.22
-      9:
-        - 2Cor.5.14-2Cor.5.15
-      10:
-        - Eph.2.18
   - question: >-
       Was the covenant of grace always administered after one and the same
       manner?

--- a/data/westminster/wlc.yaml
+++ b/data/westminster/wlc.yaml
@@ -4152,7 +4152,7 @@ questions:
     answer: >-
       The duties required in the ninth commandment are, the preserving and
       promoting of truth between man and man,[1] and the good name of our
-      neighbor, as well as our own;[12] appearing and standing for the
+      neighbor, as well as our own;[2] appearing and standing for the
       truth;[3] and from the heart,[4] sincerely,[5] freely,[6] clearly,[7]
       and fully,[8] speaking the truth, and only the truth, in matters of
       judgment and justice,[9] and in all other things whatsoever;[10] a

--- a/data/westminster/wsc.yaml
+++ b/data/westminster/wsc.yaml
@@ -1251,8 +1251,6 @@ questions:
         - 1Cor.10.16-1Cor.10.17
       e:
         - 1Cor.5.7-1Cor.5.8
-      f:
-        - 1Cor.11.28-1Cor.11.29
   - question: What is prayer?
     number: 98
     answer: >-


### PR DESCRIPTION
Hey Guys! 

About a year or so ago, we merged a PR for the `validate citations` piece of the test. This is why the build is failing. It looks to me like it is throwing some false-negatives, but it did bring attention to the following fixes for the WLC, WSC and HC.

I used [this book](https://www.crossway.org/books/creeds-confessions-and-catechisms-cob/) as the source of truth for the valid citations.