### PR TITLE
Validate Verses: Provide Failing Chapter + Article

### DIFF
--- a/test/validate_data_files.py
+++ b/test/validate_data_files.py
@@ -32,9 +32,9 @@ def read_yaml_file(filename):
     data = open(filename).read()
     return yaml.load(data, Loader=yaml.Loader)
 
-def _validate_verses(text_w_ref, obj):
+def _validate_verses(text_w_ref, obj, chapter_number = 0):
     for ref in obj['verses']:
-        assert '[' + str(ref) + ']' in text_w_ref, 'Missing Citation ' + str(ref) + ' from ' + str(obj['number'])
+        assert '[' + str(ref) + ']' in text_w_ref, 'Missing Citation ' + str(ref) + ' from chapter ' + str(chapter_number) + ' Article ' + str(obj['number'])
 
 def validate_confession(data):
     for chapter in data['chapters']:
@@ -57,7 +57,7 @@ def validate_confession(data):
         for article in chapter['articles']:
             assert isinstance(article, dict), 'Article not a dict'
             if 'verses' in article:
-                _validate_verses(article['text'], article)
+                _validate_verses(article['text'], article, chapter['number'])
 
             assert 'number' in article, 'Missing article number'
             assert 'text' in article, 'Missing text in article'


### PR DESCRIPTION
Prior to this commit, we were just providing `article[number]` as the location of the validation failure. This was not adequate for documents where the failing citation is on an article whose number is relative to the chapter rather than the document; for instance, savoy chapter 5 article 4 has a failing citation. This was showing as a failure on "chapter 4" but that was inaccurate -- it was article 4, under chapter 5.

Now, with this commit, we surface both the relevant chapter and article. If no article is given, we default to `0`.